### PR TITLE
Fix issue with old PVF connect to local church

### DIFF
--- a/application/dataentry/management/commands/migrateFormVersion.py
+++ b/application/dataentry/management/commands/migrateFormVersion.py
@@ -35,7 +35,7 @@ class Command(BaseCommand):
         for pvf in pvfs:
             modified = False
             if pvf.share_gospel_film or pvf.share_gospel_tract or pvf.share_gospel_oral or pvf.share_gospel_other:
-                pvf.share_gospel_resouce = True
+                pvf.share_gospel_resource = True
                 modified = True
 
             if pvf.how_pv_released == 'Someone came to pick the PV up from the station/shelter':

--- a/application/fixtures/initial-required-data/form_data_PVF.json
+++ b/application/fixtures/initial-required-data/form_data_PVF.json
@@ -5107,7 +5107,7 @@
       "form_tag": "pvfAwarenessLocalChurch",
       "prompt": "Connected PV to a local church in their area",
       "description": null,
-      "answer_type": 1,
+      "answer_type": 6,
       "params": null,
       "export_name": "Connected PV to a local church in their area",
       "export_params": null
@@ -5352,6 +5352,18 @@
       "answer_type": 6,
       "params": null,
       "export_name": "Shared gospel resource",
+      "export_params": null
+   }
+},
+{
+   "model": "dataentry.question",
+   "fields": {
+      "form_tag": "pvfAwarenessLocalChurchString",
+      "prompt": "Connected PV to a local church in their area",
+      "description": null,
+      "answer_type": 1,
+      "params": null,
+      "export_name": "Connected PV to a local church in their area",
       "export_params": null
    }
 },
@@ -7272,7 +7284,7 @@
 {
    "model": "dataentry.questionlayout",
    "fields": {
-      "question": "pvfAwarenessLocalChurch",
+      "question": "pvfAwarenessLocalChurchString",
       "category": "pvfAwareness202408",
       "weight": 0,
       "form_config": null
@@ -8341,6 +8353,13 @@
    }
 },
 {
+   "model": "dataentry.questionstorage",
+   "fields": {
+      "question": "pvfAwarenessLocalChurchString",
+      "field_name": "share_gospel_connect_to_local_church"
+   }
+},
+{
    "model": "dataentry.formvalidation",
    "fields": {
       "form_tag": "pvfDateRecived",
@@ -8355,6 +8374,8 @@
       "retrieve": false,
       "update": true,
       "forms": [
+         "pvfPhilippines",
+         "pvfCommon202408",
          "pvfNepal",
          "pvfIndia",
          "pvfIndiaNetwork",
@@ -8382,9 +8403,7 @@
          "pvfBangladesh",
          "pvfCambodia",
          "pvfUSA",
-         "pvfOpenSource",
-         "pvfPhilippines",
-         "pvfCommon202408"
+         "pvfOpenSource"
       ]
    }
 },


### PR DESCRIPTION
Fix typo in migrateFormVersion for PVF

Connects to #

Changes included:
When PVF version 2024.8 was added, the answer type for the question with tag pvfAwarenessLocalChurch was changed from checkbox to string.
- This broke the previous version of the PVF version (2022.6) because it needs the answer type to be checkbox.
- The new PVF version 2024.8 , needs the answer type to be string.
The answer type for the question with tag pvfAwarenessLocalChurch has been restored to checkbox
A new question with tag pvfAwarenessLocalChurchString has been added for PVF version has been added with answer type string.
