### PR TITLE
fix(LJ-570): Remove bad characters in Azure Storage view instead of reverse proxy

### DIFF
--- a/application/azure_storage/azure_storage_with_reverse_proxy.py
+++ b/application/azure_storage/azure_storage_with_reverse_proxy.py
@@ -1,20 +1,5 @@
 from django.urls import reverse
 from storages.backends.azure_storage import AzureStorage
-import re
-
-# WARN: These rules must match Azure's blob naming rules
-def remove_hidden_whitespace_characters(string: str):
-    """
-    Removes the following Unicode characters:
-      - Non-breaking space (\u00A0)
-      - Zero-width space (\u200B)
-      - Zero-width non-joiner (\u200C)
-      - Zero-width joiner (\u200D)
-      - Zero-width no-break space (\uFEFF)
-      - Narrow no-break space (\u202F)
-    """
-    pattern = r'[\u00A0\u200B\u200C\u200D\uFEFF\u202F]'
-    return re.sub(pattern, '', string)
 
 class AzureStorageWithReverseProxy(AzureStorage):
     """
@@ -27,8 +12,6 @@ class AzureStorageWithReverseProxy(AzureStorage):
         # (xxx.blob.core.windows.net/rest/of/path)
         #     container_blob_url = self.custom_client.get_blob_client(name).url
         #     return BlobClient.from_blob_url(container_blob_url, credential=credential).url
-
-        name = remove_hidden_whitespace_characters(name)
 
         path = self._get_valid_path(name)
 

--- a/application/azure_storage/views.py
+++ b/application/azure_storage/views.py
@@ -4,7 +4,21 @@ from django.http import FileResponse, Http404
 from django.views import View
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
+import re
 
+# WARN: These rules must match Azure's blob naming rules
+def remove_hidden_whitespace_characters(string: str):
+    """
+    Removes the following Unicode characters:
+      - Non-breaking space (\u00A0)
+      - Zero-width space (\u200B)
+      - Zero-width non-joiner (\u200C)
+      - Zero-width joiner (\u200D)
+      - Zero-width no-break space (\uFEFF)
+      - Narrow no-break space (\u202F)
+    """
+    pattern = r'[\u00A0\u200B\u200C\u200D\uFEFF\u202F]'
+    return re.sub(pattern, '', string)
 
 class AzureStorageReverseProxyView(APIView):
     # Gives 401 Unauthorized locally without nginx
@@ -15,7 +29,10 @@ class AzureStorageReverseProxyView(APIView):
         # in django-private-storages open source project
         # Assumes your default_storage is AzureStorageWithReverseProxy
         try:
-            file = default_storage.open(self.kwargs['path'])
+            path = self.kwargs['path']
+            cleaned_path = remove_hidden_whitespace_characters(path)
+
+            file = default_storage.open(cleaned_path)
             response = FileResponse(file)
         except ResourceNotFoundError:
             raise Http404


### PR DESCRIPTION
The reverse proxy doesn't seem to be used when directly accessing a /cloud-media link. Moving this logic to the view ensures that file names are always cleaned on GET.